### PR TITLE
fix the `function: not found` error when the `sh` doesn\'t implement …

### DIFF
--- a/targets.sh
+++ b/targets.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function trans {
     case "$1" in


### PR DESCRIPTION
…function, for example with dash